### PR TITLE
Add version string

### DIFF
--- a/gax.go
+++ b/gax.go
@@ -6,6 +6,10 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
+const (
+	Version = "0.10.0"
+)
+
 type CallOption interface {
 	Resolve(*callSettings)
 }


### PR DESCRIPTION
Allows the gax version in the client library to be set without jumping
through hoops.