### PR TITLE
Remove total retry timeout option

### DIFF
--- a/call_option.go
+++ b/call_option.go
@@ -35,7 +35,6 @@ type RetrySettings struct {
 type BackoffSettings struct {
 	DelayTimeoutSettings MultipliableDuration
 	RPCTimeoutSettings   MultipliableDuration
-	TotalTimeout         time.Duration
 }
 
 type MultipliableDuration struct {
@@ -116,17 +115,4 @@ func (w withRPCTimeoutSettings) Resolve(s *CallSettings) {
 //   to increase the timeout.
 func WithRPCTimeoutSettings(initial time.Duration, max time.Duration, multiplier float64) CallOption {
 	return withRPCTimeoutSettings(MultipliableDuration{initial, max, multiplier})
-}
-
-type withTotalRetryTimeout time.Duration
-
-func (w withTotalRetryTimeout) Resolve(s *CallSettings) {
-	s.RetrySettings.BackoffSettings.TotalTimeout = time.Duration(w)
-}
-
-// WithTotalRetryTimeout sets the total time, in milliseconds, starting from
-// when the initial request is sent, after which an error will be returned
-// regardless of the retrying attempts made meanwhile.
-func WithTotalRetryTimeout(totalRetryTimeout time.Duration) CallOption {
-	return withTotalRetryTimeout(totalRetryTimeout)
 }

--- a/call_option_test.go
+++ b/call_option_test.go
@@ -16,7 +16,6 @@ func TestCallOptions(t *testing.T) {
 			BackoffSettings{
 				MultipliableDuration{time.Second * 2, time.Second * 4, 3.0},
 				MultipliableDuration{time.Second * 5, time.Second * 7, 6.0},
-				time.Second * 8,
 			},
 		},
 	}
@@ -27,7 +26,6 @@ func TestCallOptions(t *testing.T) {
 		WithRetryCodes([]codes.Code{codes.Unavailable, codes.DeadlineExceeded}),
 		WithDelayTimeoutSettings(time.Second*2, time.Second*4, 3.0),
 		WithRPCTimeoutSettings(time.Second*5, time.Second*7, 6.0),
-		WithTotalRetryTimeout(time.Second * 8),
 	}
 	callOptions(opts).Resolve(settings)
 

--- a/invoke_test.go
+++ b/invoke_test.go
@@ -15,7 +15,7 @@ var (
 		// initial, max, multiplier
 		WithDelayTimeoutSettings(100*time.Millisecond, 300*time.Millisecond, 1.5),
 		WithRPCTimeoutSettings(50*time.Millisecond, 500*time.Millisecond, 3.0),
-		WithTotalRetryTimeout(1000 * time.Millisecond),
+		WithTimeout(1000*time.Millisecond),
 	}
 )
 
@@ -25,7 +25,7 @@ func TestInvokeWithTimeout(t *testing.T) {
 	Invoke(ctx, func(childCtx context.Context) error {
 		_, ok = childCtx.Deadline()
 		return nil
-	}, WithTimeout(10000*time.Millisecond))
+	}, WithTimeout(1000*time.Millisecond))
 	if !ok {
 		t.Errorf("expected call to have an assigned timeout")
 	}
@@ -37,7 +37,7 @@ func TestInvokeWithOKResponseWithTimeout(t *testing.T) {
 	err := Invoke(ctx, func(childCtx context.Context) error {
 		resp = 42
 		return nil
-	}, WithTimeout(10000*time.Millisecond))
+	}, WithTimeout(1000*time.Millisecond))
 	if resp != 42 || err != nil {
 		t.Errorf("expected call to return nil and set resp to 42")
 	}


### PR DESCRIPTION
Changes the retrying call to use the parent total timeout.